### PR TITLE
Fix stack peek

### DIFF
--- a/src/Stack/Stack.ts
+++ b/src/Stack/Stack.ts
@@ -51,7 +51,7 @@ export class Stack<T> {
     peek(): T | null {
 
         if (this._store.length > 0) {
-            return this._store[0];
+            return this._store[this._store.length - 1];
         }
 
         return null;

--- a/tests/Stack/Stack.spec.ts
+++ b/tests/Stack/Stack.spec.ts
@@ -32,7 +32,7 @@ describe('Stack', () => {
         stack.push(2);
         stack.push(3);
 
-        expect(stack.peek()).equal(1);
+        expect(stack.peek()).equal(3);
 
     });
 


### PR DESCRIPTION
## Summary
- make `Stack.peek` return the last pushed element
- update stack tests for the corrected behavior

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'chai')*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f76b4daf4832cb2a64c3ec36d7468