### PR TITLE
Fix lint command usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,3 +507,12 @@ hooks with the following command:
 ```bash
 git config core.hooksPath .githooks
 ```
+
+## Development
+
+Install dependencies before running lint or tests:
+
+```bash
+npm install
+npm run lint
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "mocha dist/tests/**/*.spec.js  --reporter spec",
     "test_watch": "tsc && mocha dist/tests/**/*.spec.js  --reporter spec --watch",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha dist/tests/**/*.spec.js  -- -R spec",
-    "cover:nyx": "nyc npm test"
+    "cover:nyx": "nyc npm test",
+    "lint": "tslint -c tslint.json -p tsconfig.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add `lint` script to package.json
- document running lint in README

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683ffbc474bc832c88c30d05b7b2b8db